### PR TITLE
chore: remove unused env key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,6 @@ jobs:
         run: npm install
 
       - name: Build Storybook
-        env:
-          STORYBOOK_AZURE_MAPS_KEY: ${{ secrets.STORYBOOK_AZURE_MAPS_KEY }}
         run: npm run build-storybook
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
The app now uses anonymous auth, STORYBOOK_AZURE_MAPS_KEY is no longer being used.